### PR TITLE
snap/snapcraft.yaml: retrieve firmware.vfat from kernel package

### DIFF
--- a/apt/sources.list.d/sources.list
+++ b/apt/sources.list.d/sources.list
@@ -1,0 +1,4 @@
+deb http://ports.ubuntu.com jammy main universe restricted multiverse
+deb http://ports.ubuntu.com jammy-updates main universe restricted multiverse
+deb http://ports.ubuntu.com jammy-backports main universe restricted multiverse
+deb http://ports.ubuntu.com jammy-security main universe restricted multiverse

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,8 @@ architectures:
 
 parts:
   boot-firmware:
+    after:
+      - device-tree
     source: boot-firmware/
     plugin: dump
     organize:
@@ -25,3 +27,38 @@ parts:
     plugin: dump
     organize:
       '*': usr/share/doc/boot-firmware/
+
+  # Note: The device tree for EVK boards are pre-compiled in the kernel, so we
+  #       could just use it. But for ODM vendor, you need to prepare your own
+  #       device-tree following by ubuntu document.
+  device-tree:
+    plugin: nil
+    build-packages:
+      - devscripts
+      - dosfstools
+      - mtools
+    build-environment:
+      - DEBIAN_FRONTEND: noninteractive
+    override-build: |
+      set -eux
+      env
+      chdist -d tmp -a arm64 create ubuntu
+      cp -vr ${SNAPCRAFT_PROJECT_DIR}/apt/sources.list.d tmp/ubuntu/etc/apt/
+      chdist -d tmp -a arm64 apt-get ubuntu update
+      IMG_PKG_NAME=$(chdist -d tmp -a arm64 apt-cache ubuntu depends linux-image-mtk | grep 'Depends:' | awk -F: '{print $2}')
+      MODULE_PKG_NAME=$(chdist -d tmp -a arm64 apt-cache ubuntu depends ${IMG_PKG_NAME} | grep 'Depends:' | grep 'linux-modules-.*-mtk' | awk -F: '{print $2}')
+      chdist -d tmp -a arm64 apt-get ubuntu download ${MODULE_PKG_NAME}
+      dpkg-deb --extract linux-modules-*-mtk_*_arm64.deb tmp
+      
+      find tmp/lib/firmware/*/device-tree/mediatek/{genio-1200-evk.dtb,genio-1200-evk,mt8395} \
+          \( -name '*.dtb' -or -name '*.dtbo' \) \
+          -exec install -D -t tmp/FIRMWARE/mediatek/genio-1200-evk/ {} +
+
+      fallocate -l 32M firmware.vfat
+      mkfs.vfat firmware.vfat
+      mcopy -i firmware.vfat -s tmp/FIRMWARE ::
+      cp firmware.vfat ${SNAPCRAFT_PART_INSTALL}/firmware.vfat
+    organize:
+      'firmware.vfat': usr/lib/boot-firmware/firmware.vfat
+    prime:
+      - usr/lib/boot-firmware/firmware.vfat


### PR DESCRIPTION
This patch removed pre-build firmware.vfat, instead, it retrieves firmware.vfat from kernel package. So we can use the device-tree that is updated in time.

This patch is also a prerequisite for workflow patch. It will be use to maintain the different boot-assets for both jammy and noble.